### PR TITLE
azure-mgmt-compute 34.1.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,28 +1,31 @@
 {% set name = "azure-mgmt-compute" %}
-{% set version = "29.1.0" %}
+{% set version = "34.1.0" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/azure-mgmt-compute-{{ version }}.zip
-  sha256: 2d5a1bae7f5d307ca1e850d7e83fed9c839d4f635b10a4b8d3f8bc6098ac2888
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.zip
+  sha256: cd9d35d1cc1b8cb0bd241ad55c91b77d14e04ae73c632ada1140135f9c217fe1
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: true  # [py<38]
 
 requirements:
   host:
+    - wheel
+    - setuptools
     - pip
-    - python >=3.6
+    - python
   run:
-    - python >=3.6
-    - azure-common >=1.1,<1.2.0
-    - azure-mgmt-core >=1.3.1,<2.0.0
-    - msrest >=0.6.21
+    - python
+    - isodate >=0.6.1
+    - typing-extensions >=4.6.0
+    - azure-common >=1.1
+    - azure-mgmt-core>=1.3.2
 
 test:
   imports:
@@ -37,17 +40,10 @@ about:
   home: https://github.com/Azure/azure-sdk-for-python
   summary: Microsoft Azure Compute Management Client Library for Python
   license: MIT
-  license_file:
-    - LICENSE
+  license_file: LICENSE
+  license_family: MIT
   description: |
-    This is the Microsoft Azure Compute Management Client Library. 
-    This package has been tested with Python 3.6+. For a more complete 
-    view of Azure libraries, see the [azure sdk python release](https://aka.ms/azsdk/python/all).
-
-    To learn how to use this package, see the [quickstart guide](https://aka.ms/azsdk/python/mgmt).
-
-    PyPI: [https://pypi.org/project/azure-mgmt-compute/](https://pypi.org/project/azure-mgmt-compute/)
-
+    This is the Microsoft Azure Compute Management Client Library.
   doc_url: https://azure.github.io/azure-sdk-for-python
   dev_url: https://github.com/Azure/azure-sdk-for-python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.zip
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
   sha256: cd9d35d1cc1b8cb0bd241ad55c91b77d14e04ae73c632ada1140135f9c217fe1
 
 build:


### PR DESCRIPTION
azure-mgmt-compute 34.1.0 

**Destination channel:** Defaults

### Links

- [PKG-13695]
- dev_url:        https://github.com/Azure/azure-sdk-for-python/tree/azure-mgmt-compute_34.1.0
- conda_forge:    https://github.com/conda-forge/azure-mgmt-compute-feedstock
- pypi:           https://pypi.org/project/azure-mgmt-compute/34.1.0
- pypi inspector: https://inspector.pypi.io/project/azure-mgmt-compute/34.1.0

### Explanation of changes:

- new version number


[PKG-13695]: https://anaconda.atlassian.net/browse/PKG-13695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ